### PR TITLE
Batch up APT installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,9 @@
 ---
-- name: install linux-image-extra
-  become: yes
-  apt:
-    name: "linux-image-extra-{{ ansible_kernel }}"
-    state: present
-
 - name: install zram-config
   become: yes
   apt:
-    name: zram-config
+    name: '{{ item }}'
     state: present
+  with_items:
+    - 'linux-image-extra-{{ ansible_kernel }}'
+    - zram-config


### PR DESCRIPTION
Batching up APT installs is more performant and more reliable as it can reuse HTTP connections.