### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.zram-config }
+    - role: gantsign.zram-config
 ```
 
 More Roles From GantSign


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.