### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: '2.7'
 
 # Spin off separate builds for each of the following versions of Ansible
 env:
-  - ANSIBLE_VERSION=2.3.3
+  - ANSIBLE_VERSION=2.4.6
   - ANSIBLE_VERSION=2.6.2
 
 # Require the standard build environment

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing zram-config for compressed RAM swap.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer support versions earlier than 2.4.