### PR TITLE
Dropped support for Ubuntu Wily

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements
         * Ubuntu
 
             * Trusty (14.04)
-            * Wily (15.10)
             * Xenial (16.04)
 
         * Note: other versions are likely to work but have not been tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
-        - wily
         - xenial
   galaxy_tags:
     - zram


### PR DESCRIPTION
Ubuntu no longer support Wily.