### PR TITLE
Updated role to match new Ansible Galaxy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Ansible Role: Zram Config
 =========================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-zram-config.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-zram-config)
-[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.zram--config-blue.svg)](https://galaxy.ansible.com/gantsign/zram-config)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-zram-config/master/LICENSE)
+[![Build Status](https://travis-ci.org/gantsign/ansible_role_zram_config.svg?branch=master)](https://travis-ci.org/gantsign/ansible_role_zram_config)
+[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.zram__config-blue.svg)](https://galaxy.ansible.com/gantsign/zram_config)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible_role_zram_config/master/LICENSE)
 
 Role to install Zram Config for compressed RAM swap.
 
@@ -30,7 +30,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-    - role: gantsign.zram-config
+    - role: gantsign.zram_config
 ```
 
 More Roles From GantSign

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for zram-config
+# defaults file for zram_config

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for zram-config
+# handlers file for zram_config

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint:
   name: yamllint
 
 platforms:
-  - name: ansible-role-zram-config-01
+  - name: ansible_role_zram_config-01
     image: ubuntu:14.04
 
 provisioner:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: ansible-role-zram-config
+    - role: ansible_role_zram_config


### PR DESCRIPTION
Unfortunately Ansible Galaxy renamed this role due to the following feature: https://github.com/ansible/galaxy/issues/974 (if you set the `role_name` Ansible will replace the hyphens in your role name with underscores).